### PR TITLE
feat: add navbar and prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # SeniorForum - a CS 495 Project
+
 ### Collaborators: Jacob Aid, Caleb Burdette, Navamin Leelarburanathanakoon, Jade Cartolano
 
 Seniors need a place to socialize with like-minded individuals, ask questions, or learn about events. App is to be used by seniors and possibly by caretakers as well.
@@ -6,6 +7,7 @@ Seniors need a place to socialize with like-minded individuals, ask questions, o
 Techstack: MERN (MongoDB, Express, ReactJS, NodeJS)
 
 ### Links:
+
 - [Kanban board](https://trello.com/invite/b/hdwoN30o/ATTIdba27cd137d485b23d0aa044ce93184eCD0FE8D9/cs-495-kanban-board)
 - [Pitch presentation](https://docs.google.com/presentation/d/1QS5a9HF5ync9hC1AEP0dQ1LnQmpf7cvBAOkL0lOAX88/edit#slide=id.g35f391192_029)
 - [Brainstorming doc](https://docs.google.com/document/d/1zo7Y78hqRt5Y6DlvqzMewt8645pc6ixZ2LDVWqdc1c8/edit)
@@ -20,6 +22,7 @@ Techstack: MERN (MongoDB, Express, ReactJS, NodeJS)
 - Run `npm install` in the root directory as well as the `./client` folder
 
 Server and client must be running simultaneously, for this you need two terminals running.
+
 1. Server: In one terminal window, `cd` into the `/server` folder and run `npm start` to start the server.
 2. Client: In another terminal window, `cd` into the `/client` folder and run `npm start` to start the client.
 3. Visit `localhost:3000` to see the client in action.

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,20 +1,8 @@
-import React, {useEffect, useState} from "react";
+import React from "react";
+import Home from "./pages/Home";
 
 function App() {
-  const [message, setMessage] = useState("");
-
-  useEffect(() => {
-
-    // fetching input from server's "/test" endpoint
-    fetch("/test")
-        .then((res) => res.text())
-        .then((data) => setMessage(data))
-        .catch((err) => console.log(err));
-  }, []);
-
-  return (
-      <h1>{message ? message : "Loading..."}</h1>
-  );
+  return <Home />;
 }
 
 export default App;

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,0 +1,41 @@
+import React from "react";
+import "../styles/navbar.css";
+
+function Navbar() {
+  return (
+    <header>
+      <div className="container">
+        <div id="nav-box">
+          <div id="nav-title-box">
+            <img
+              src="https://brand.ua.edu/wp-content/themes/ua-theme/assets/img/ua-square-logo.png"
+              alt="alabamaLogo"
+            />
+            <div>
+              <h1 id="nav-title">Senior Forum</h1>
+              <span id="nav-subtitle">Connecting caregivers of Alabama</span>
+            </div>
+          </div>
+          <nav>
+            <ul>
+              <li className="nav-item">
+                <a href="/home">HOME</a>
+              </li>
+              <li className="nav-item">
+                <a href="/categories">CATEGORIES</a>
+              </li>
+              <li className="nav-item">
+                <a href="/about">ABOUT</a>
+              </li>
+              <li className="nav-item">
+                <a href="/account">MY ACCOUNT</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export default Navbar;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles/global.css";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+import Navbar from "../components/Navbar";
+
+function Home() {
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    // fetching input from server's "/test" endpoint
+    fetch("/test")
+      .then((res) => res.text())
+      .then((data) => setMessage(data))
+      .catch((err) => console.log(err));
+  }, []);
+
+  return (
+    <div>
+      <Navbar />
+      <h1>{message ? message : "Loading..."}</h1>
+    </div>
+  );
+}
+
+export default Home;

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -1,0 +1,10 @@
+* {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 1100px;
+  margin: auto;
+}

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -1,0 +1,45 @@
+header {
+  background-color: #900f0f;
+  color: white;
+}
+
+#nav-box {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 120px;
+}
+
+#nav-title-box {
+  margin-right: auto;
+  display: flex;
+  align-items: center;
+  min-width: 250px;
+  justify-content: space-between;
+}
+
+#nav-title {
+  font-weight: normal;
+  font-size: 25px;
+}
+
+#nav-subtitle {
+  font-size: 12px;
+}
+
+#nav-title-box img {
+  height: 50px;
+}
+
+.nav-item {
+  font-size: 12px;
+  list-style: none;
+  display: inline-block;
+  padding: 0 20px;
+}
+
+.nav-item a {
+  text-decoration: none;
+  font-weight: bold;
+  color: inherit;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "create-react-app": "^5.0.1",
         "express": "^4.18.2"
+      },
+      "devDependencies": {
+        "prettier": "3.2.4"
       }
     },
     "node_modules/accepts": {
@@ -796,6 +799,21 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/prettier": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "dependencies": {
     "create-react-app": "^5.0.1",
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "prettier": "3.2.4"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -4,9 +4,9 @@ const app = express();
 
 // test server endpoint
 app.get("/test", (req, res) => {
-    res.send("Hello world! - from Express");
+  res.send("Hello world! - from Express");
 });
 
 app.listen(PORT, () => {
-    console.log(`Server listening on port ${PORT}`);
+  console.log(`Server listening on port ${PORT}`);
 });


### PR DESCRIPTION
## Describe your changes

This PR adds some directories to the `client` folder, including `./styles`, `./pages`, `./components`
- `App.js` no longer renders the test header, but instead renders a `Home` component
- A draft `Navbar` is added to the `Home` page with some styling
- Global CSS is added for uniform styling
- Used `Prettier` to format code before pushing

![image](https://github.com/kevinleey/SeniorForum/assets/55768372/eb90e8a5-3ecc-4d58-bb46-410fc2e55e10)



Please refer to individual commits for changes and further details